### PR TITLE
Bugfix: when no errors occurred errors where still reported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.1] - 2019-04-24
-
-- Added better typedefinitions for JarbField.
-
-## [2.0.0] - 2019-04-17
-
-- Re-wrote the library in TypeScript.
-
-## [1.0.0] - 2018-04-23
-
 - The first stable version of this library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarb-final-form",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Validating forms through JaRB.",
   "files": [
     "lib"

--- a/src/JarbField.tsx
+++ b/src/JarbField.tsx
@@ -162,7 +162,11 @@ export class JarbField<FieldValue, T extends HTMLElement> extends Component<
         validator(value, allValues, meta)
       );
       return Promise.all(promises).then(values => {
-        return values.filter(v => v !== undefined);
+        const errors = values.filter(v => v !== undefined);
+
+        // If there are no errors return undefined to indicate
+        // that everything is a-ok.
+        return errors.length === 0 ? undefined : errors;
       });
     };
 

--- a/tests/JarbField.test.tsx
+++ b/tests/JarbField.test.tsx
@@ -46,7 +46,7 @@ describe('Component: JarbField', () => {
     setConstraints(constraints);
   }
 
-  describe('The validators prop', () => {
+  describe('the validators prop', () => {
     it('should when validators are provided by the user include them in the validation', async done => {
       setup(filledConstraints());
 
@@ -169,7 +169,7 @@ describe('Component: JarbField', () => {
     });
   });
 
-  describe('validators', () => {
+  describe('adding jarb validators', () => {
     test('string which is required, and has minimumLength and maximumLength', async done => {
       setup(filledConstraints());
 
@@ -303,6 +303,61 @@ describe('Component: JarbField', () => {
           const errors = await validate('Superman', {});
 
           expect(errors).toEqual(['numberFractions']);
+          done();
+        } catch (error) {
+          done.fail(error);
+        }
+      } else {
+        done.fail();
+      }
+    });
+  });
+
+  describe('enhancedValidate', () => {
+    let validate: FieldValidator<number>;
+
+    beforeEach(() => {
+      setup({});
+
+      const isEven: FieldValidator<number> = value =>
+        value % 2 === 0 ? undefined : 'Not even';
+      const isSmallerThan10: FieldValidator<number> = value =>
+        value < 10 ? undefined : 'Bigger than 10';
+
+      const jarbField = shallow(
+        <JarbField
+          name="Name"
+          jarb={{ validator: 'Hero.name', label: 'Name' }}
+          validators={[isEven, isSmallerThan10]}
+          component="input"
+        />
+      );
+
+      // @ts-ignore
+      validate = jarbField.find(Field).props().validate;
+    });
+
+    it('should filter out results which return undefined so only errors remain', async done => {
+      if (validate) {
+        try {
+          const errors = await validate(12, {});
+
+          expect(errors).toEqual(['Bigger than 10']);
+          done();
+        } catch (error) {
+          done.fail(error);
+        }
+      } else {
+        done.fail();
+      }
+    });
+
+    it('should when there are no errors return undefined', async done => {
+      if (validate) {
+        try {
+          const errors = await validate(2, {});
+
+          expect(errors).toEqual(undefined);
           done();
         } catch (error) {
           done.fail(error);


### PR DESCRIPTION
The reason for this is because `final-form` interprets every non
`undefined` as an errors. Before we returned an empty array to signify
non errors.

Now we return `undefined` when there are no errors fixing the issue.