### PR TITLE
Feature: added boolean required validator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.3] - 2019-08-17
+
+- Added boolean required validator.
+
+## [0.0.2] - 2019-07-21
+
 - The first stable version of this library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jarb-final-form",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4221,9 +4221,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4588,9 +4588,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash.escape": {
@@ -4848,9 +4848,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -6017,9 +6017,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -6742,38 +6742,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unset-value": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jarb-final-form",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Validating forms through JaRB.",
   "files": [
     "lib"

--- a/src/JarbField.tsx
+++ b/src/JarbField.tsx
@@ -80,8 +80,13 @@ export class JarbField<FieldValue, T extends HTMLElement> extends Component<
         );
 
         if (fieldConstraints.required) {
-          const requiredValidator = Validators.makeRequired(label);
-          validatorFunctions.push(requiredValidator);
+          if (field === 'boolean') {
+            const requiredValidator = Validators.makeBooleanRequired(label);
+            validatorFunctions.push(requiredValidator);
+          } else {
+            const requiredValidator = Validators.makeRequired(label);
+            validatorFunctions.push(requiredValidator);
+          }
         }
 
         if (field === 'text') {

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,6 +13,7 @@ export type FieldType =
   | 'password'
   | 'file'
   | 'image'
+  | 'boolean'
   | 'text';
 
 export interface FieldConstraints {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import {
 
 // List of <input> types sorted on most specific first.
 const inputTypes: FieldType[] = [
+  'boolean',
   'color',
   'datetime-local',
   'datetime',

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -14,7 +14,28 @@ export function makeRequired(label: string): FieldValidator<any> {
   return function validateRequired(
     value: any
   ): Promise<RequiredError | undefined> {
-    if (value == null || value === '') {
+    if (value == null || value === '' || typeof value === 'boolean') {
+      const error: RequiredError = {
+        type: 'ERROR_REQUIRED',
+        label,
+        value,
+        reasons: {
+          required: 'required'
+        }
+      };
+
+      return Promise.resolve(error);
+    }
+
+    return Promise.resolve(undefined);
+  };
+}
+
+export function makeBooleanRequired(label: string): FieldValidator<any> {
+  return function validateBooleanRequired(
+    value: any
+  ): Promise<RequiredError | undefined> {
+    if (value !== true) {
       const error: RequiredError = {
         type: 'ERROR_REQUIRED',
         label,

--- a/tests/JarbField.test.tsx
+++ b/tests/JarbField.test.tsx
@@ -19,6 +19,9 @@ describe('Component: JarbField', () => {
       .spyOn(validators, 'makeRequired')
       .mockImplementation(() => () => 'required');
     jest
+      .spyOn(validators, 'makeBooleanRequired')
+      .mockImplementation(() => () => 'booleanRequired');
+    jest
       .spyOn(validators, 'makeMinimumLength')
       .mockImplementation(() => () => 'minimumLength');
     jest
@@ -311,6 +314,40 @@ describe('Component: JarbField', () => {
         done.fail();
       }
     });
+
+    test('boolean which is required', async done => {
+      setup(filledConstraints());
+
+      const jarbField = shallow(
+        <JarbField
+          name="Name"
+          jarb={{ validator: 'Hero.partOfHeroAssociation', label: 'Name' }}
+          component="input"
+        />
+      );
+
+      // Trigger the render again to check if it re-uses the validators correctly.
+      jarbField.setState({});
+
+      const { name, validate, component } = jarbField.find(Field).props();
+      expect(name).toBe('Name');
+      expect(component).toBe('input');
+
+      expect(validators.makeBooleanRequired).toHaveBeenCalledTimes(1);
+      expect(validators.makeBooleanRequired).toHaveBeenCalledWith('Name');
+      if (validate) {
+        try {
+          const errors = await validate('Superman', {});
+
+          expect(errors).toEqual(['booleanRequired']);
+          done();
+        } catch (error) {
+          done.fail(error);
+        }
+      } else {
+        done.fail();
+      }
+    });
   });
 
   describe('enhancedValidate', () => {
@@ -423,6 +460,19 @@ function filledConstraints(): Constraints {
         min: null,
         max: null,
         name: 'salary'
+      },
+      partOfHeroAssociation: {
+        javaType: 'boolean',
+        types: ['boolean'],
+        required: true,
+        minimumLength: null,
+        maximumLength: null,
+        fractionLength: null,
+        radix: null,
+        pattern: null,
+        min: null,
+        max: null,
+        name: 'partOfHeroAssociation'
       }
     }
   };


### PR DESCRIPTION
This validator adds when the field is `required` and a `boolean`.
The behavior is that the user must then set the `boolean` to `true`
otherwise the field is invalid.

Also fixed flaky validator tests which used `resolves` but did not
return the `Promise`. This causes tests to silently fail, but succeed
in the CI. Rewritten to use `async` with `done` instead