### PR TITLE
improvement: improved constraints type.

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,5 @@
 export type FieldType =
+  | 'enum'
   | 'color'
   | 'datetime-local'
   | 'datetime'
@@ -19,14 +20,14 @@ export type FieldType =
 export interface FieldConstraints {
   javaType: string;
   types: FieldType[];
-  required: boolean | null;
-  minimumLength: number | null;
-  maximumLength: number | null;
-  fractionLength: number | null;
-  radix: number | null;
-  pattern: string | null;
-  min: number | null;
-  max: number | null;
+  required?: boolean | null;
+  minimumLength?: number | null;
+  maximumLength?: number | null;
+  fractionLength?: number | null;
+  radix?: number | null;
+  pattern?: string | null;
+  min?: number | null;
+  max?: number | null;
   name: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import {
 
 // List of <input> types sorted on most specific first.
 const inputTypes: FieldType[] = [
+  'enum',
   'boolean',
   'color',
   'datetime-local',


### PR DESCRIPTION
The `FieldConstraints` have changed and the `null` values are no
longer sent down the line in newer versions of `jarb`. Added `undefined`
as a possible type. For back-wards compatibility the `null` is still also
one of the available values.

Added the `enum` type `FieldType` which is new.