### PR TITLE
fix: the validateRequired validator should guard agains blank strings

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -14,7 +14,15 @@ export function makeRequired(label: string): FieldValidator<any> {
   return function validateRequired(
     value: any
   ): Promise<RequiredError | undefined> {
-    if (value == null || value === '' || typeof value === 'boolean') {
+    if (
+      value == null ||
+      value === '' ||
+      // Prevent users from validating boolean values by always
+      // considering it an error, they should use `makeBooleanRequired`
+      // instead.
+      typeof value === 'boolean' ||
+      (typeof value === 'string' && value.trim() === '')
+    ) {
       const error: RequiredError = {
         type: 'ERROR_REQUIRED',
         label,

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -72,6 +72,29 @@ test('required', async done => {
   });
 
   checkValidator({
+    value: ' ',
+    expected: {
+      type: 'ERROR_REQUIRED',
+      label: 'Name',
+      value: ' ',
+      reasons: { required: 'required' }
+    }
+  });
+
+  checkValidator({
+    value: '  ',
+    expected: {
+      type: 'ERROR_REQUIRED',
+      label: 'Name',
+      value: '  ',
+      reasons: { required: 'required' }
+    }
+  });
+
+  // Prevent users from validating boolean values by always
+  // considering it an error, they should use `makeBooleanRequired`
+  // instead.
+  checkValidator({
     value: true,
     expected: {
       type: 'ERROR_REQUIRED',
@@ -92,6 +115,8 @@ test('required', async done => {
   });
 
   checkValidator({ value: 'h', expected: undefined });
+  checkValidator({ value: 'h ', expected: undefined });
+  checkValidator({ value: ' h ', expected: undefined });
   checkValidator({ value: 'henkie', expected: undefined });
 
   done();


### PR DESCRIPTION
Strings like this one: `" "` with only blanks should not make the
it passed the `validateRequired` validator.

The solution was to trim the string and check if that produces an empty
string, if so then return the error.

fixes #16