### PR TITLE
fix: required check on empty arrays and objects

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -19,11 +19,13 @@ export function makeRequired(label: string): FieldValidator<any> {
     if (
       value == null ||
       value === '' ||
+      (typeof value === 'string' && value.trim() === '') ||
+      (Array.isArray(value) && value.length === 0) ||
+      (typeof value === 'object' && Object.keys(value).length === 0) ||
       // Prevent users from validating boolean values by always
       // considering it an error, they should use `makeBooleanRequired`
       // instead.
-      typeof value === 'boolean' ||
-      (typeof value === 'string' && value.trim() === '')
+      typeof value === 'boolean'
     ) {
       const error: RequiredError = {
         type: 'ERROR_REQUIRED',

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -33,7 +33,7 @@ function makeValidatorChecker(
 }
 
 test('required', async () => {
-  expect.assertions(11);
+  expect.assertions(15);
 
   const validator = makeRequired('Name');
 
@@ -112,10 +112,32 @@ test('required', async () => {
     }
   });
 
+  await checkValidator({
+    value: [],
+    expected: {
+      type: 'ERROR_REQUIRED',
+      label: 'Name',
+      value: [],
+      reasons: { required: 'required' }
+    }
+  });
+
+  await checkValidator({
+    value: {},
+    expected: {
+      type: 'ERROR_REQUIRED',
+      label: 'Name',
+      value: {},
+      reasons: { required: 'required' }
+    }
+  });
+
   await checkValidator({ value: 'h', expected: undefined });
   await checkValidator({ value: 'h ', expected: undefined });
   await checkValidator({ value: ' h ', expected: undefined });
   await checkValidator({ value: 'henkie', expected: undefined });
+  await checkValidator({ value: { test: true }, expected: undefined });
+  await checkValidator({ value: ['test'], expected: undefined });
 });
 
 test('booleanRequired', async () => {


### PR DESCRIPTION
When a multiple select field is required, an empty array as value is
valid, while the array should contain at least 1 item. The same works
for maps/associative arrays, which are objects in JavaScript.

Changed required validator to return required error when value is an
empty array or object.

Closes #39